### PR TITLE
Add support for setting raven_version from pyproject.toml, add license 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(NetCDF REQUIRED)
 # Add Python files
 find_package(pybind11 CONFIG REQUIRED)
 pybind11_add_module(_core MODULE src/main.cpp)
+target_compile_definitions(_core PRIVATE RAVEN_VERSION_INFO=${RAVEN_VERSION} REQUIRED)
 target_compile_definitions(_core PRIVATE VERSION_INFO=${PROJECT_VERSION})
 
 # Find header & source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ verbose = true
 
 [tool.scikit-build.cmake.define]
 HELPERS = "helpers"
+RAVEN_VERSION = 3.6
 RAVEN_URL = "https://www.civil.uwaterloo.ca/raven/files/v3.6/RavenSource_v3.6.zip"
 RAVEN_SHA256 = "a962f3377425868d9cc535b6858e0457f5307636f99466ee37ab66ecfbcaf35c"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,8 @@ namespace py = pybind11;
 PYBIND11_MODULE(_core, m) {
     m.doc() = R"pbdoc(A Python wrapper to setup and build the hydrologic modelling framework Raven.)pbdoc";
 
+    m.attr("__raven_version__") = MACRO_STRINGIFY(RAVEN_VERSION_INFO);
+
 #ifdef VERSION_INFO
     m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
 #else

--- a/src/raven_hydro/__init__.py
+++ b/src/raven_hydro/__init__.py
@@ -1,3 +1,19 @@
-from ._core import __doc__, __version__
+"""
+   Copyright 2023 Ouranos Inc. and contributors
 
-__all__ = ["__doc__", "__version__"]
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
+from ._core import __doc__, __raven_version__, __version__
+
+__all__ = ["__doc__", "__raven_version__", "__version__"]


### PR DESCRIPTION
Working on my end! Example:

```python
import raven_hydro

raven_hydro.__raven_version__
'3.6'

raven_hydro.__version__
'0.1.0'

raven_hydro.__doc__
'A Python wrapper to setup and build the hydrologic modelling framework Raven.'
```