### PR TITLE
Prepare v0.2.1

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -10,10 +10,13 @@ jobs:
     name: Build Source distribution and Wheels
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+#      fail-fast: false
+      include:
+        - os: ubuntu-latest
+          python-version: "3.8"
+#      matrix:
+#        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+#        python-version: ["3.8", "3.9", "3.10", "3.11"]
     defaults:
       run:
         shell: bash -l {0}
@@ -25,36 +28,36 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Set up Python${{ matrix.python-version }} with NetCDF4 (conda)
-        if: ${{ matrix.os == 'windows-latest' }}
-        uses: mamba-org/provision-with-micromamba@main
-        with:
-          cache-downloads: true
-          micromamba-version: 'latest'
-          extra-specs: |
-            python=${{ matrix.python-version }}
-            build
-            virtualenv
-      - name: Install NetCDF4 (Ubuntu/apt)
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install libnetcdf-dev
-      - name: Install NetCDF4 (macOS/homebrew)
-        if: ${{ matrix.os == 'macos-latest' }}
-        uses: tecolicom/actions-use-homebrew-tools@v1
-        with:
-          tools: netcdf
-          cache: yes
+#      - name: Set up Python${{ matrix.python-version }} with NetCDF4 (conda)
+#        if: ${{ matrix.os == 'windows-latest' }}
+#        uses: mamba-org/provision-with-micromamba@main
+#        with:
+#          cache-downloads: true
+#          micromamba-version: 'latest'
+#          extra-specs: |
+#            python=${{ matrix.python-version }}
+#            build
+#            virtualenv
+#      - name: Install NetCDF4 (Ubuntu/apt)
+#        if: ${{ matrix.os == 'ubuntu-latest' }}
+#        run: |
+#          sudo apt-get update
+#          sudo apt-get install libnetcdf-dev
+#      - name: Install NetCDF4 (macOS/homebrew)
+#        if: ${{ matrix.os == 'macos-latest' }}
+#        uses: tecolicom/actions-use-homebrew-tools@v1
+#        with:
+#          tools: netcdf
+#          cache: yes
       - name: Install packaging libraries (Ubuntu/macOS)
         if: ${{ matrix.os != 'windows-latest' }}
         run: ${{ steps.pyinstalled.outputs.python-path }} -m pip install build virtualenv
-      - name: Build a binary wheel (Windows)
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: python -m build --wheel
-      - name: Build a binary wheel (Ubuntu/macOS)
-        if: ${{ matrix.os != 'windows-latest' }}
-        run: ${{ steps.pyinstalled.outputs.python-path }} -m build --wheel
+#      - name: Build a binary wheel (Windows)
+#        if: ${{ matrix.os == 'windows-latest' }}
+#        run: python -m build --wheel
+#      - name: Build a binary wheel (Ubuntu/macOS)
+#        if: ${{ matrix.os != 'windows-latest' }}
+#        run: ${{ steps.pyinstalled.outputs.python-path }} -m build --wheel
       - name: Build a source tarball (Ubuntu)
         if: |
           (matrix.os == 'ubuntu-latest') && (matrix.python-version == '3.8')

--- a/.github/workflows/tag-testpypi.yml
+++ b/.github/workflows/tag-testpypi.yml
@@ -6,14 +6,18 @@ on:
       - '*'
 
 jobs:
+  # Wheels no longer offered until library linking is clarified.
   build:
     name: Build Source distribution and Wheels
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+#      fail-fast: false
+      include:
+        - os: ubuntu-latest
+          python-version: "3.8"
+#      matrix:
+#        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+#        python-version: ["3.8", "3.9", "3.10", "3.11"]
     defaults:
       run:
         shell: bash -l {0}
@@ -25,36 +29,36 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Set up Python${{ matrix.python-version }} with NetCDF4 (conda)
-        if: ${{ matrix.os == 'windows-latest' }}
-        uses: mamba-org/provision-with-micromamba@main
-        with:
-          cache-downloads: true
-          micromamba-version: 'latest'
-          extra-specs: |
-            python=${{ matrix.python-version }}
-            build
-            virtualenv
-      - name: Install NetCDF4 (Ubuntu/apt)
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install libnetcdf-dev
-      - name: Install NetCDF4 (macOS/homebrew)
-        if: ${{ matrix.os == 'macos-latest' }}
-        uses: tecolicom/actions-use-homebrew-tools@v1
-        with:
-          tools: netcdf
-          cache: yes
+#      - name: Set up Python${{ matrix.python-version }} with NetCDF4 (conda)
+#        if: ${{ matrix.os == 'windows-latest' }}
+#        uses: mamba-org/provision-with-micromamba@main
+#        with:
+#          cache-downloads: true
+#          micromamba-version: 'latest'
+#          extra-specs: |
+#            python=${{ matrix.python-version }}
+#            build
+#            virtualenv
+#      - name: Install NetCDF4 (Ubuntu/apt)
+#        if: ${{ matrix.os == 'ubuntu-latest' }}
+#        run: |
+#          sudo apt-get update
+#          sudo apt-get install libnetcdf-dev
+#      - name: Install NetCDF4 (macOS/homebrew)
+#        if: ${{ matrix.os == 'macos-latest' }}
+#        uses: tecolicom/actions-use-homebrew-tools@v1
+#        with:
+#          tools: netcdf
+#          cache: yes
       - name: Install packaging libraries (Ubuntu/macOS)
         if: ${{ matrix.os != 'windows-latest' }}
         run: ${{ steps.pyinstalled.outputs.python-path }} -m pip install build virtualenv
-      - name: Build a binary wheel (Windows)
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: python -m build --wheel
-      - name: Build a binary wheel (Ubuntu/macOS)
-        if: ${{ matrix.os != 'windows-latest' }}
-        run: ${{ steps.pyinstalled.outputs.python-path }} -m build --wheel
+#      - name: Build a binary wheel (Windows)
+#        if: ${{ matrix.os == 'windows-latest' }}
+#        run: python -m build --wheel
+#      - name: Build a binary wheel (Ubuntu/macOS)
+#        if: ${{ matrix.os != 'windows-latest' }}
+#        run: ${{ steps.pyinstalled.outputs.python-path }} -m build --wheel
       - name: Build a source tarball (Ubuntu)
         if: |
           (matrix.os == 'ubuntu-latest') && (matrix.python-version == '3.8')

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.2.1 (2023-05-25)
+
+* Raven-hydro only offers source distributions until issues arising from library linking/bundling have been resolved.
+
 ## 0.2.0 (2023-05-16)
 
 * Updated Raven version to v3.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 keywords = ["raven", "hydrologic", "model", "cmake"]
 dynamic = ["readme"]
-version = "0.2.0"
+version = "0.2.1"
 dependencies = []
 
 [project.urls]


### PR DESCRIPTION
### Changes

This creates a new version that publishes only the source distribution. Until I can figure out how to bundle NetCDF and supporting libraries with the package, we should not be offering wheels.