### PR TITLE
Add support for optional NetCDF builds, update raven code base

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!--Please ensure the PR fulfills the following requirements! -->
+<!-- If this is your first PR, make sure to add your details to the AUTHORS.md! -->
+### Pull Request Checklist:
+- [ ] This PR addresses an already opened issue (for bug fixes / features)
+    - This PR fixes #xyz
+- [ ] Tests for the changes have been added (for bug fixes / features)
+  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
+- [ ] CHANGES.rst has been updated (with summary of main changes)
+
+### What kind of change does this PR introduce?
+
+* ...
+
+### Does this PR introduce a breaking change?
+
+
+
+### Other information:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
           pre-commit run --all-files
 
   build:
-    name: Python${{ matrix.python-version }} on ${{ matrix.os }} (conda=${{ matrix.conda }})
+    name: Python${{ matrix.python-version }} on ${{ matrix.os }} (conda=${{ matrix.conda }}) (install_args=${{ matrix.install_args }})
     needs: black
     runs-on: ${{ matrix.os }}
     strategy:
@@ -93,6 +93,7 @@ jobs:
           tools: netcdf
           cache: yes
       - name: Check for OPeNDAP Support
+        if: (!matrix.install_args)
         run: |
           nc-config --has-dap
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
           pre-commit run --all-files
 
   build:
-    name: Python${{ matrix.python-version }} (${{ matrix.os }}, conda=${{ matrix.conda }}), args=${{ matrix.install_args }})
+    name: Python${{ matrix.python-version }} (${{ matrix.os }}, conda=${{ matrix.conda }}, args=${{ matrix.install_args }})
     needs: black
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
           pre-commit run --all-files
 
   build:
-    name: Python${{ matrix.python-version }} on ${{ matrix.os }} (conda=${{ matrix.conda }}) (install_args=${{ matrix.install_args }})
+    name: Python${{ matrix.python-version }} (${{ matrix.os }}, conda=${{ matrix.conda }}), args=${{ matrix.install_args }})
     needs: black
     runs-on: ${{ matrix.os }}
     strategy:
@@ -100,7 +100,7 @@ jobs:
       - name: Install raven-hydro
         if: ${{ !matrix.conda }}
         run: |
-          ${{ steps.pyinstalled.outputs.python-path }} -m pip install --editable .  ${{ matrix.install_args }}
+          ${{ steps.pyinstalled.outputs.python-path }} -m pip install --editable . ${{ matrix.install_args }}
       - name: Test raven-hydro
         if: ${{ !matrix.conda }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: ["ubuntu-latest", "macos-latest"]
         conda: [false]
+        install_args: [""]
         include:
           - python-version: "3.8"
             os: windows-latest
@@ -55,6 +56,10 @@ jobs:
           - python-version: "3.10"
             os: macos-latest
             conda: true
+          - python-version: "3.11"
+            os: ubuntu-latest
+            conda: false
+            install_args: "-Ccmake.define.USE_NETCDF=false"
     defaults:
       run:
         shell: bash -l {0}
@@ -76,24 +81,8 @@ jobs:
           create-args: >-
             python=${{ matrix.python-version }}
 
-#      - name: Set LD_PRELOAD for NetCDF source files (Ubuntu/conda)
-#        if: (matrix.os == 'ubuntu-latest') && (matrix.conda)
-#        run: |
-#          echo "LD_PRELOAD=$(find /home/runner/micromamba-root/envs/raven-hydro -name libnetcdf.*so | head -n 1)" >> $GITHUB_ENV
-
-#      - name: Link NetCDF/HDF (macOS/conda)
-#        if: (matrix.os == 'macos-latest') && (matrix.conda)
-#        run: |
-#          sudo ln -s $(find /Users/runner/micromamba-root/envs/raven-hydro -name libcrypto.*dylib | head -n 1) /usr/local/lib/libcrypto.3.dylib
-#          sudo ln -s $(find /Users/runner/micromamba-root/envs/raven-hydro -name libdf.*dylib | head -n 1) /usr/local/lib/libdf.0.dylib
-#          sudo ln -s $(find /Users/runner/micromamba-root/envs/raven-hydro -name libhdf5.*dylib | head -n 1) /usr/local/lib/libhdf5.310.dylib
-#          sudo ln -s $(find /Users/runner/micromamba-root/envs/raven-hydro -name libhdf5_hl.*dylib | head -n 1) /usr/local/lib/libhdf5_hl.310.dylib
-#          sudo ln -s $(find /Users/runner/micromamba-root/envs/raven-hydro -name libmfhdf.*dylib | head -n 1) /usr/local/lib/libmfhdf.0.dylib
-#          sudo ln -s $(find /Users/runner/micromamba-root/envs/raven-hydro -name libnetcdf.*dylib | head -n 1) /usr/local/lib/libnetcdf.19.dylib
-#          sudo ln -s $(find /Users/runner/micromamba-root/envs/raven-hydro -name libsz.*dylib | head -n 1) /usr/local/lib/libsz.2.dylib
-
       - name: Install NetCDF4 (Ubuntu/apt)
-        if: (matrix.os == 'ubuntu-latest') && (!matrix.conda)
+        if: (matrix.os == 'ubuntu-latest') && (!matrix.install_args) && (!matrix.conda)
         run: |
           sudo apt-get update
           sudo apt-get install libnetcdf-dev
@@ -110,7 +99,7 @@ jobs:
       - name: Install raven-hydro
         if: ${{ !matrix.conda }}
         run: |
-          ${{ steps.pyinstalled.outputs.python-path }} -m pip install --editable .
+          ${{ steps.pyinstalled.outputs.python-path }} -m pip install --editable .  ${{ matrix.install_args }}
       - name: Test raven-hydro
         if: ${{ !matrix.conda }}
         run: |
@@ -119,7 +108,7 @@ jobs:
       - name: Install raven-hydro (conda)
         if: ${{ matrix.conda }}
         run: |
-          python -m pip install --editable .
+          python -m pip install --editable . ${{ matrix.install_args }}
       - name: Test raven-hydro (conda)
         if: ${{ matrix.conda }}
         run: |

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,5 @@
+## Credits
+
+### Development Lead
+
+* Trevor James Smith <smith.trevorj@ouranos.ca> [@Zeitsperre](https://github.com/Zeitsperre)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.2.3 (2023-07-04)
+
+* Raven-hydro now supports building raven model without NetCDF4 support (see README.md for details).
+
 ## 0.2.2 (2023-06-05)
 
 * Building Raven-hydro from sources available on pip within an Anaconda environment is now supported.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,13 +16,13 @@ cmake_minimum_required(VERSION 3.24...3.26)
 # Setup Raven Project
 PROJECT(${SKBUILD_PROJECT_NAME} LANGUAGES CXX VERSION ${SKBUILD_PROJECT_VERSION})
 
-set(raven_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/_deps/raven-src)
+SET(raven_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/_deps/raven-src)
 
 # Remove deprecation warnings for GCC
-if(CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated")
-    message(STATUS "Modified compile flags: ${CMAKE_CXX_FLAGS}")
-endif(CMAKE_COMPILER_IS_GNUCXX)
+IF(CMAKE_COMPILER_IS_GNUCXX)
+    add_compile_options(-Wno-deprecated)
+    message(STATUS "Modified compile flags with '-Wno-deprecated'")
+ENDIF(CMAKE_COMPILER_IS_GNUCXX)
 
 IF(NOT EXISTS ${raven_SOURCE_DIR} OR ${ALWAYS_DOWNLOAD})
     IF(NOT EXISTS ${raven_SOURCE_DIR})
@@ -45,30 +45,29 @@ ELSE()
     message(STATUS "Sources found: ${raven_SOURCE_DIR}")
 ENDIF()
 
-# Find Anaconda environment library path
-# if(DEFINED ENV{CONDA_PREFIX})
-#     set(CONDA_LIBRARY_PATH $ENV{CONDA_PREFIX}/lib)
-# else()
-#     set(CONDA_LIBRARY_PATH "")
-# endif()
+IF(USE_NETCDF)
+    # Add NetCDF support flag
+    add_compile_options(-Dnetcdf)
+    message(STATUS "Modified compile flags with '-Dnetcdf'")
 
-# Find NetCDF library
-list(APPEND CMAKE_MODULE_PATH ${HELPERS})
-find_package(NetCDF REQUIRED)
+    # Find NetCDF library
+    list(APPEND CMAKE_MODULE_PATH ${HELPERS})
+    find_package(NetCDF REQUIRED)
 
-# Find ZLib library
-find_package(ZLIB REQUIRED)
+    # Find ZLib library
+    find_package(ZLIB REQUIRED)
+ENDIF()
 
 # Add Python files
-set(PYBIND11_NEWPYTHON ON)
+SET(PYBIND11_NEWPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 pybind11_add_module(_core MODULE src/main.cpp)
 target_compile_definitions(_core PRIVATE RAVEN_VERSION_INFO=${RAVEN_VERSION} REQUIRED)
 target_compile_definitions(_core PRIVATE VERSION_INFO=${PROJECT_VERSION})
 
 # Find header & source
-file(GLOB HEADER "${raven_SOURCE_DIR}/*.h")
-file(GLOB SOURCE "${raven_SOURCE_DIR}/*.cpp")
+FILE(GLOB HEADER "${raven_SOURCE_DIR}/*.h")
+FILE(GLOB SOURCE "${raven_SOURCE_DIR}/*.cpp")
 
 # Add source files to build
 add_executable(raven
@@ -85,25 +84,28 @@ source_group("Source Files" FILES ${SOURCE})
 #     include_directories(${NetCDF_INCLUDE_DIRS})
 # endif()
 
-# Link relevant libraries to build
-include_directories(${NetCDF_INCLUDE_DIRS})
-target_link_libraries(raven PUBLIC ${NetCDF_LIBRARIES})
+IF(USE_NETCDF)
+    # Link relevant NetCDF libraries to build
+    include_directories(${NetCDF_INCLUDE_DIRS})
+    target_link_libraries(raven PUBLIC ${NetCDF_LIBRARIES})
+ENDIF()
+
 target_compile_features(raven PUBLIC cxx_std_11)
 set_target_properties(raven PROPERTIES LINKER_LANGUAGE CXX)
 
 # Install library to environment Python /lib
-install(TARGETS _core LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME})
+INSTALL(TARGETS _core LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME})
 
 # Install binary to environment /bin
-if(WIN32)
+IF(WIN32)
   install(TARGETS raven DESTINATION ${SKBUILD_SCRIPTS_DIR})
-else()
+ELSE()
   add_custom_command(
           TARGET raven POST_BUILD
           COMMAND ${CMAKE_COMMAND} -E copy
                   ${CMAKE_CURRENT_BINARY_DIR}/raven
                   ${SKBUILD_SCRIPTS_DIR}/raven)
-endif()
+ENDIF()
 
 # Add License for Raven after building library
 add_custom_command(

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This project differs from [RavenPy](https://github.com/CSHS-CWRA/RavenPy) by sol
 ### Installation
 
 > **Warning**
-> This build of Raven requires that NetCDF4 libraries are installed on the system, exposed on the `$PATH`, and discoverable using the `FindNetCDF.cmake` helper script.
+> By default, this build of Raven requires that NetCDF4 libraries are installed on the system, exposed on the `$PATH`, and discoverable using the `FindNetCDF.cmake` helper script.
 >
 > On Linux, this can be provided by the `libnetcdf-dev` system library; On macOS by the `netcdf` homebrew package; And on Windows by using UNIDATA's [pre-built binaries](https://docs.unidata.ucar.edu/netcdf-c/current/winbin.html).
 >
@@ -36,6 +36,12 @@ This project differs from [RavenPy](https://github.com/CSHS-CWRA/RavenPy) by sol
 
 ```shell
 $ pip install raven-hydro
+```
+
+To install `raven-hydro` from PyPI **without NetCDF support**:
+
+```shell
+$ pip install raven-hydro -Ccmake.define.USE_NETCDF=false
 ```
 
 For development purposes, we recommend cloning the repository and performing an `--editable` installation:

--- a/build/_deps/raven-src/Makefile
+++ b/build/_deps/raven-src/Makefile
@@ -17,7 +17,7 @@ appname := Raven.exe
 CXX      := g++
 CXXFLAGS := -Wno-deprecated
 # some compilers require the c++11 flag, some may not
-CXXFLAGS += std=-c++11
+CXXFLAGS += -std=c++11
 
 srcfiles := $(shell find . -name "*.cpp")
 objects  := $(patsubst %.cpp, %.o, $(srcfiles))

--- a/build/_deps/raven-src/RavenMain.cpp
+++ b/build/_deps/raven-src/RavenMain.cpp
@@ -52,7 +52,7 @@ int main(int argc, char* argv[])
   time_struct tt;
   int         nEnsembleMembers;
   
-  Options.version="3.6";
+  Options.version="3.7";
 #ifdef _NETCDF_ 
   Options.version+=" w/ netCDF";
 #endif

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,6 @@ HELPERS = "helpers"
 ALWAYS_DOWNLOAD = false
 RAVEN_VERSION = 3.7
 RAVEN_URL = "https://www.civil.uwaterloo.ca/raven/files/v3.7/RavenSource_v3.7.zip"
-# The following build is broken for macOS at time of writing:
-# RAVEN_SHA256 = "7aabf0295e0e28ffee424ff29cabc14301d95b27ad1fc3971bad634bc9fa08f4"
 RAVEN_SHA256 = "1460658be8d47d9d1f3a25ffde881c0c2be72b5ad3b048811142d45b01c62bdb"
 
 [tool.scikit-build.metadata]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 keywords = ["raven", "hydrologic", "model", "cmake"]
 dynamic = ["readme"]
-version = "0.2.2"
+version = "0.2.3"
 dependencies = []
 
 [project.urls]
@@ -53,19 +53,17 @@ experimental = true
 [tool.scikit-build.cmake]
 minimum-version = "3.24"
 build-type = "Release"
-args = [
-  "-DCMAKE_CXX_FLAGS='-Dnetcdf'"
-]
 verbose = true
 
 [tool.scikit-build.cmake.define]
+USE_NETCDF = true
 HELPERS = "helpers"
 ALWAYS_DOWNLOAD = false
 RAVEN_VERSION = 3.7
 RAVEN_URL = "https://www.civil.uwaterloo.ca/raven/files/v3.7/RavenSource_v3.7.zip"
 # The following build is broken for macOS at time of writing:
 # RAVEN_SHA256 = "7aabf0295e0e28ffee424ff29cabc14301d95b27ad1fc3971bad634bc9fa08f4"
-RAVEN_SHA256 = "5fce9688f1c1004ee36d607b226dac856fb8d35d58a6caeb663bdbf177231f07"
+RAVEN_SHA256 = "1460658be8d47d9d1f3a25ffde881c0c2be72b5ad3b048811142d45b01c62bdb"
 
 [tool.scikit-build.metadata]
 readme.provider = "scikit_build_core.metadata.fancy_pypi_readme"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ readme.provider = "scikit_build_core.metadata.fancy_pypi_readme"
 [tool.scikit-build.sdist]
 include = [
   "./CMakeLists.txt",
+  "AUTHORS.md",
   "CHANGES.md",
   "LICENSE",
   "README.md",


### PR DESCRIPTION
## Changes

* We can now install Raven without NetCDF support, if desired.
  * There is also an accompanying build to test for this feature
* Added an AUTHORS.md file
* Added a Pull Request template
* Updated version of Raven model (`sha256=="1460658be8d47d9d1f3a25ffde881c0c2be72b5ad3b048811142d45b01c62bdb"`)